### PR TITLE
update 1.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: c574035dd85ef7f5b1d6d9c9f639fcaff51fcf85a397c5b6d721e161e6077f51
   patches:
     # avoid relying on /usr/bin/patch
-    - patch.patch
+    # - patch.patch
 
 build:
   number: 0
@@ -39,7 +39,7 @@ test:
   imports:
     - lmdb
   commands:
-    - py.test tests
+    - pytest tests
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ test:
     - pip check
 
 about:
-  home: https://lmdb.readthedocs.io/
+  home: https://github.com/jnwatson/py-lmdb
   license: OLDAP-2.8
   license_family: Other
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,13 @@
 {% set version = "1.4.1" %}
-
 package:
   name: python-lmdb
   version: {{ version }}
-
 source:
   url: https://github.com/jnwatson/py-lmdb/archive/refs/tags/py-lmdb_{{ version }}.tar.gz
   sha256: c574035dd85ef7f5b1d6d9c9f639fcaff51fcf85a397c5b6d721e161e6077f51
   patches:
     # avoid relying on /usr/bin/patch
-    # - patch.patch
+    - patch.patch
 
 build:
   number: 0
@@ -29,7 +27,6 @@ requirements:
     - wheel
   run:
     - python
-
 test:
   source_files:
     - tests
@@ -41,7 +38,6 @@ test:
   commands:
     - py.test tests
     - pip check
-
 about:
   home: https://github.com/jnwatson/py-lmdb
   license: OLDAP-2.8
@@ -56,9 +52,3 @@ about:
     disk-based databases.
     python-lmdb is a Python binding for LMDB including a bundled
     version of LMDB.
-  doc_url: https://lmdb.readthedocs.io/
-  dev_url: https://github.com/jnwatson/py-lmdb
-
-extra:
-  recipe-maintainers:
-    - pitrou

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
   imports:
     - lmdb
   commands:
-    - py.test tests
+    - pytest tests
     - pip check
 about:
   home: https://github.com/jnwatson/py-lmdb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,12 @@
-{% set name = "python-lmdb" %}
-{% set pypi_name = "lmdb" %}
-{% set github_name = "py-lmdb" %}
-{% set version = "1.4.0" %}
-{% set sha256 = "39f6c4ee145d28d17025d350720abb6f95db816514e868db57444fdef51cbb47" %}
+{% set version = "1.4.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: python-lmdb
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/lmdb-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/jnwatson/py-lmdb/archive/refs/tags/py-lmdb_{{ version }}.tar.gz
+  sha256: c574035dd85ef7f5b1d6d9c9f639fcaff51fcf85a397c5b6d721e161e6077f51
   patches:
     # avoid relying on /usr/bin/patch
     - patch.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,3 +52,5 @@ about:
     disk-based databases.
     python-lmdb is a Python binding for LMDB including a bundled
     version of LMDB.
+  doc_url: https://lmdb.readthedocs.io/
+  dev_url: https://github.com/jnwatson/py-lmdb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,3 +54,9 @@ about:
     version of LMDB.
   doc_url: https://lmdb.readthedocs.io/
   dev_url: https://github.com/jnwatson/py-lmdb
+
+extra:
+  recipe-maintainers:
+    - pitrou
+    - h-vetinari
+    - xhochy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   skip: true  # [s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install .  --no-deps --no-build-isolation -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
   imports:
     - lmdb
   commands:
-    - pytest tests
+    - py.test tests
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [s390x]
   script: {{ PYTHON }} -m pip install .  --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
## Python-lmdb  1.4.1 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1721)
[Upstream]( https://github.com/jnwatson/py-lmdb)

# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Removed unnecessary formatting to simplify the `meta.yaml`